### PR TITLE
Feature: List of Languages Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ uv run benchmark tokenizer=openai-community/gpt2 sample_size=0.1
 # Custom output filename
 uv run benchmark tokenizer=meta-llama/Meta-Llama-3-8B output_name=llama_results
 
+# Run on a custom set of natural languages
+uv run benchmark tokenizers=openai-community/gpt2 natural_lang_list=hin_Deva,jpn_Jpan,fra_Latn max_workers=8
+
 # Example: comprehensive multi-tokenizer run
 uv run benchmark tokenizer=openai-community/gpt2,google/gemma-3-27b-it,Xenova/gpt-4,meta-llama/Llama-3.1-8B,moonshotai/Kimi-K2-Instruct,Qwen/Qwen3-30B-A3B-Instruct-2507,openai/gpt-oss-120b max_workers=10
 ```
@@ -82,6 +85,35 @@ Tips:
 ### How It Works (one paragraph)
 
 Tokka-Bench streams real text from FineWeb-2 (top N natural languages), FineWeb (English), and StarCoder (top N coding languages). It tokenizes equal-sized samples per language, computes metrics, aggregates global Unicode/script stats, and saves results in a simple JSON format for the dashboard.
+
+### Reference: Command Line Arguments
+- `--tokenizer`: 
+	- **Description**: Describes the tokenizer to benchmark. Usually a HuggingFace model tag e.g `openai-community/gpt2`.
+	- **Usage**: `--tokenizer=openai-community/gpt2`
+- `--tokenizers`: 
+	- **Description**: Alternative to `--tokenizer` if multiple tokenizers are to be benchmarked. Separate different tokenizers by a *comma*(,).
+	- **Usage**: `--tokenizers="openai-community/gpt2,meta-llama/Llama-3.1-8B"`
+- `--sample_size`: 
+	- **Description**: Size of the data to be benchmarked on (in MBs).
+	- **Usage**: `--sample_size=100` (Benchmark on 100 MBs).
+- `--output_name`:
+	- **Description**: Directory name for benchmark output JSON.
+	- **Usage**: `--output_name=MyOutput`
+- `--output_names`:
+	- **Description**: If multiple tokenizers are being benchmarked and their results are to be stored separately you can use this field.
+	- **Usage**: `--output_names="TokenizerBenchmark1,TokenizerBenchmark2"` (Counts should match tokenizer count).
+- `--max_workers`:
+	- **Description**: Maximum CPU workers assigned to the benchmarking task.
+	- **Usage**: `--max_workers=8`
+- `--natural_n`:
+	- **Description**: Top N natural languages to benchmark on based on their total size in the FineWeb-2 corpus.
+	- **Usage**: `--natural_n=10` (Defaults to 99)
+- `--code_n`:
+	- **Description**: Number of programming languages to benchmark on.
+	- **Usage**: `--code_n=10` (Defaults to 20)
+- `--natural_lang_list`:
+	- **Description**: Use this if you want to test on specific set of natural languages rather than the top languages based on size. To specify a language use it's ISO-639 code along with it's script indicator e.g `fra_Latn` for french in latin script. Refer `src/fineweb-2-languages.csv`'s `Subset` column to get these values for your desired language and script pairs.
+	- **Usage**: `--natural_lang_list="hin_Deva,fra_Latn"` (Test against Hindi and French).
 
 ### Troubleshooting
 

--- a/src/tokka_bench/cli.py
+++ b/src/tokka_bench/cli.py
@@ -168,6 +168,7 @@ def parse_config():
         "max_workers": config.get("max_workers", DEFAULT_MAX_WORKERS),
         "natural_n": config.get("natural_n", None),
         "code_n": config.get("code_n", None),
+        "natural_lang_list": config.get("natural_lang_list", None)
     }
 
 
@@ -315,6 +316,9 @@ def main():
             config["natural_n"]
             if config["natural_n"] is not None
             else DEFAULT_NATURAL_LANGUAGES,
+            config['natural_lang_list'].split(",")
+            if config['natural_lang_list'] is not None
+            else [],
             config["code_n"]
             if config["code_n"] is not None
             else DEFAULT_CODE_LANGUAGES,

--- a/src/tokka_bench/data_utils.py
+++ b/src/tokka_bench/data_utils.py
@@ -75,6 +75,13 @@ def load_coding_languages(n: int = 10) -> List[Dict[str, str]]:
 
     return coding_langs
 
+def get_natural_languages(df: pd.DataFrame, lang_list: List[str], n: int = 5) -> List[Dict[str, str]]:
+    """Identify which natural language loader to use."""
+    if len(lang_list) > 0:
+        return get_listed_languages(df, lang_list)
+    else:
+        return get_top_languages(df, n)
+
 
 def get_top_languages(df: pd.DataFrame, n: int = 5) -> List[Dict[str, str]]:
     """Get the top N natural languages by size."""
@@ -104,6 +111,23 @@ def get_top_languages(df: pd.DataFrame, n: int = 5) -> List[Dict[str, str]]:
             "source": "fineweb2",
         }
         for _, row in top_langs.iterrows()
+    ]
+
+
+def get_listed_languages(df: pd.DataFrame, lang_list: List[str]) -> List[Dict[str, str]]:
+    """Get the mentioned languages."""
+    df = df.dropna(subset=["Name", "Script"])
+    # Only keep languages that are mentioned by the user.
+    df = df[df["Subset"].isin(lang_list)]
+
+    return [
+        {
+            "iso_code": row["ISO 639-3 code"],
+            "script": row["Script"],
+            "name": row["Name"],
+            "source": "fineweb2",
+        }
+        for _, row in df.iterrows()
     ]
 
 

--- a/src/tokka_bench/fast_benchmark.py
+++ b/src/tokka_bench/fast_benchmark.py
@@ -24,7 +24,7 @@ from transformers import AutoTokenizer
 
 from .data_utils import (
     get_english_fineweb,
-    get_top_languages,
+    get_natural_languages,
     load_coding_languages,
     load_language_data,
     load_real_sample_text,
@@ -289,6 +289,7 @@ def run_benchmark(
     sample_size_mb: float = 2.0,
     max_workers: int = 8,
     natural_n: int = 99,
+    natural_lang_list: List[str] = [],
     code_n: int = 20,
 ) -> Dict[str, Any]:
     """Benchmark multiple tokenizers across many languages quickly.
@@ -329,8 +330,9 @@ def run_benchmark(
     # Languages: English + configurable natural/code language counts (defaults match classic)
     english = get_english_fineweb()
     df = load_language_data()
-    natural_languages = get_top_languages(df, n=natural_n)
+    natural_languages = get_natural_languages(df, lang_list=natural_lang_list, n=natural_n)
     coding_languages = load_coding_languages(n=code_n)
+
     all_languages: List[Dict[str, str]] = (
         [english] + natural_languages + coding_languages
     )


### PR DESCRIPTION
## Summary
This change allows the user to provide a list of natural languages that they want to benchmark tokenizer/s against.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Changes Made
- New knob added in `src/tokka_bench/cli.py` to specify natural languages to test against.
- Updated `src/tokka_bench/fast_benchmark.py` to accept a new argument for specified natural languages.
- New functions added in `src/tokka_bench/data_utils.py` for loading language data either on the specified list of natural languages or the top n natural languages.
- 
## Testing
Describe the tests you ran to verify your changes:

- [x] Tested basic benchmark functionality: `uv run benchmark tokenizer=openai-community/gpt2 sample_size=0.01`
- [x] Tested dashboard functionality: `uv run streamlit run cli/visualize.py`
- [x] Tested with a custom list of languages.

**Test Configuration**:
- Python version: 3.13.7
- Operating system: Ubuntu 22.04.3 LTS
- Tokenizers tested: `answerdotai/ModernBERT`, `ai4bharat/Indic-Bert`, `ai4bharat/IndicBartSS`.

## Documentation

- [x] Updated README.md (if needed)
- [x] Added examples for new features

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested my changes thoroughly
- [x] Any dependent changes have been merged and published in downstream modules
